### PR TITLE
fix issue #24, #28 and #43

### DIFF
--- a/src/jfif.c
+++ b/src/jfif.c
@@ -549,6 +549,14 @@ int jfif_decode(void *ctxt, BMP *pb)
             int vx = j * jfif->comp_info[2].samp_factor_h / sfh_max;
             usrc = yuv_datbuf[1] + uy * yuv_stride[1] + ux;
             vsrc = yuv_datbuf[2] + vy * yuv_stride[2] + vx;
+            if (usrc >= yuv_datbuf[1] + yuv_stride[1] * yuv_height[1] * sizeof(int)) {
+                printf("usrc overflow\n");
+                return -1;
+            }
+            if (vsrc >= yuv_datbuf[2] + yuv_stride[2] * yuv_height[2] * sizeof(int)) {
+                printf("vsrc overflow\n");
+                return -1;
+            }
             yuv_to_rgb(*ysrc, *usrc, *vsrc, bdst + 2, bdst + 1, bdst + 0);
             bdst += 3;
             ysrc += 1;


### PR DESCRIPTION
The overflow is caused by the accessing to the memory buffer without checking the boundary.
https://github.com/rockcarry/ffjpeg/blob/0fa4cf8a86d7f23a3e8336343c1895aa634fdc76/src/jfif.c#L550-L552

ffjpeg access `yuv_datbuf[1]` with offset `uy * yuv_stride[1] + ux` without checking whether it is over the buffer size
https://github.com/rockcarry/ffjpeg/blob/0fa4cf8a86d7f23a3e8336343c1895aa634fdc76/src/jfif.c#L443-L444