### PR TITLE
exit program when bmp file is oversize

### DIFF
--- a/src/ffjpeg.c
+++ b/src/ffjpeg.c
@@ -26,7 +26,10 @@ int main(int argc, char *argv[])
         bmp_save(&bmp, "decode.bmp");
         bmp_free(&bmp);
     } else if (strcmp(argv[1], "-e") == 0) {
-        bmp_load(&bmp, argv[2]);
+        if (bmp_load(&bmp, argv[2]) == -1) {
+            printf("failed to load bmp file: %s !\n", argv[2]);
+            return -1;
+        }
         jfif = jfif_encode(&bmp);
         bmp_free(&bmp);
         jfif_save(jfif, "encode.jpg");


### PR DESCRIPTION
fix issue #47

When bmp's size is out of range, it returns without assign memory buffer to `pb->pdata` and did not exit the program.
So the program crashes when it tries to access the `pb->data` in jfif.c:763, which is a invalid memory address.
https://github.com/rockcarry/ffjpeg/blob/d5cfd49f304e2b8eafc0d473d1c217b1c761243b/src/jfif.c#L757-L763