### PR TITLE
fix issue #55: insecure error handling logic in `bmp_load`

### DIFF
--- a/src/bmp.c
+++ b/src/bmp.c
@@ -43,7 +43,8 @@ int bmp_load(BMP *pb, char *file)
     pb->stride = ALIGN(pb->width * 3, 4);
     if ((long long)pb->stride * pb->height >= 0x80000000) {
         printf("bmp's width * height is out of range !\n");
-        goto done;
+        fclose(fp);
+        return -1;
     }
     pb->pdata  = malloc((size_t)pb->stride * pb->height);
     if (pb->pdata) {
@@ -52,11 +53,13 @@ int bmp_load(BMP *pb, char *file)
             pdata -= pb->stride;
             fread(pdata, pb->stride, 1, fp);
         }
+    } else {
+        fclose(fp);
+        return -1;
     }
 
-done:
-    if (fp) fclose(fp);
-    return pb->pdata ? 0 : -1;
+    fclose(fp);
+    return 0;
 }
 
 int bmp_create(BMP *pb, int w, int h)

--- a/src/huffman.c
+++ b/src/huffman.c
@@ -164,6 +164,12 @@ static void huffman_encode_init_from_codelist(HUFCODEC *phc)
     /* 对 templist 按 depth 进行快速排序 */
     qsort(templist, n, sizeof(HUFCODEITEM), cmp_depth_item);
 
+    // 检查最小depth是否小于0
+    if (templist[0].depth<=0) {
+        printf("huffman encode error: depth <= 0 !\n");
+        return;
+    }
+
 #if ENABLE_DEBUG_DUMP
     // dump done code list
     dump_huffman_codelist(" done ---", templist, n, -1);
@@ -190,11 +196,13 @@ static void huffman_encode_init_from_codelist(HUFCODEC *phc)
 
     k    = 0;
     code = 0;
-    for (j=templist[0].depth-1; j<MAX_HUFFMAN_CODE_LEN; j++) {
-        for (i=0; i<huftab[j]; i++) {
-            templist[k++].code = code++;
+    if (n>0) {
+        for (j=templist[0].depth-1; j<MAX_HUFFMAN_CODE_LEN; j++) {
+            for (i=0; i<huftab[j]; i++) {
+                templist[k++].code = code++;
+            }
+            code <<= 1;
         }
-        code <<= 1;
     }
 
 #if ENABLE_DEBUG_DUMP


### PR DESCRIPTION
This PR fix issue #55 by not determining the return code of `bmp_load` with external controlled `bmp->pdata`.